### PR TITLE
Add Github Auth based on username and token

### DIFF
--- a/native_package_install.py
+++ b/native_package_install.py
@@ -96,7 +96,7 @@ def fetch_packages(vendor_dir, packages):
         url = format_url(package)
         request = urllib2.Request(url)
         if token:
-            request.add_header("Authorization", "Basic {token}".format(token))
+            request.add_header("Authorization", "Basic {token}".format(token=token))
         try:
             print("Downloading {namespace}/{name} {version}".format(**package))
             tar_file = urllib2.urlopen(request)

--- a/native_package_install.py
+++ b/native_package_install.py
@@ -88,8 +88,7 @@ def fetch_packages(vendor_dir, packages):
     token = None
 
     if (user and auth_token):
-        token = base64.b64encode("{user}:{auth_token}".format(user, auth_token))
-        request.add_header("Authorization", "Basic {token}".format(token))
+        token = base64.b64encode("{user}:{auth_token}".format(user=user, auth_token=auth_token))
 
     for package in packages:
         tar_filename = format_tar_file(vendor_dir, package)


### PR DESCRIPTION
Allows users to set environment variables `GITHUB_ELM_AUTH_TOKEN` and `GITHUB_ELM_AUTH_USER` to access private repositories.
