### PR TITLE
elm_deps_sync: avoid unwanted diffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+cache: pip
+python:
+  # see https://docs.travis-ci.com/user/languages/python/ for options
+  - "2.7" # hypothesis's minimum version for 2.x
+  - "3.3" # hypothesis's minimum version for 3.x
+  - "3.4" # trusty
+  - "3.5" # >= xenial
+  - "3.6-dev"
+  - "nightly"
+# command to install dependencies
+install:
+  - "pip install -r dev-requirements.txt"
+# command to run tests
+script:
+  - "python -m pytest tests/ -v"
+notifications:
+  email: false

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,4 @@
+enum34==1.1.6
+hypothesis==3.6.0
+py==1.4.31
+pytest==3.0.3

--- a/elm_deps_sync.py
+++ b/elm_deps_sync.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 
 import sys
+from collections import OrderedDict
 import json
 import argparse
 
@@ -41,12 +42,13 @@ def sync_versions(top_level_file, spec_file, quiet=False, dry=False, note_test_d
             test_deps[package_name] = package_version
 
     if note_test_deps:
-        spec['test-dependencies'] = test_deps
+        spec['test-dependencies'] = sorted_deps(test_deps)
 
     if len(messages) > 0 or note_test_deps:
         print('{number} packages changed.'.format(number=len(messages)))
 
         if not dry:
+            spec['dependencies'] = sorted_deps(spec['dependencies'])
             with open(spec_file, 'w') as f:
                 json.dump(spec, f, sort_keys=False, indent=4)
         else:
@@ -56,6 +58,10 @@ def sync_versions(top_level_file, spec_file, quiet=False, dry=False, note_test_d
             print('\n'.join(messages))
     else:
         print('No changes needed.')
+
+
+def sorted_deps(deps):
+    return OrderedDict(sorted(deps.items()))
 
 
 def main():

--- a/elm_deps_sync.py
+++ b/elm_deps_sync.py
@@ -16,7 +16,7 @@ def sync_versions(top_level_file, spec_file, quiet=False, dry=False, note_test_d
         top_level = json.load(f)
 
     with open(spec_file) as f:
-        spec = json.load(f)
+        spec = json.load(f, object_pairs_hook=OrderedDict)
 
     messages = []
 

--- a/tests/test_elm_deps_sync.py
+++ b/tests/test_elm_deps_sync.py
@@ -1,0 +1,38 @@
+from collections import OrderedDict
+import json
+
+import pytest
+
+import elm_deps_sync
+
+
+def test_spec_order_is_preserved(tmpdir):
+    top_level_file = tmpdir.join('elm-package.json')
+    spec_file = tmpdir.join('spec-elm-package.json')
+
+    top_level = {
+        'dependencies': OrderedDict([
+            ('NoRedInk/top-3', '1.0.0 <= v <= 1.0.0'),
+            ('NoRedInk/top-1', '1.0.0 <= v <= 1.0.0'),
+            ('NoRedInk/top-2', '1.0.0 <= v <= 1.0.0'),
+        ])
+    }
+    top_level_file.write(json.dumps(top_level))
+
+    spec = {
+        'dependencies': OrderedDict([
+            ('NoRedInk/top-2', '1.0.0 <= v <= 1.0.0'),
+            ('NoRedInk/top-1', '1.0.0 <= v <= 1.0.0'),
+        ])
+    }
+    spec_file.write(json.dumps(spec))
+
+    elm_deps_sync.sync_versions(
+        str(top_level_file),
+        str(spec_file),
+        quiet=False,
+        dry=False,
+        note_test_deps=True)
+
+    new_spec = json.loads(spec_file.read(), object_pairs_hook=OrderedDict)
+    assert new_spec['dependencies'].keys() == ['NoRedInk/top-1', 'NoRedInk/top-2', 'NoRedInk/top-3']

--- a/tests/test_elm_deps_sync.py
+++ b/tests/test_elm_deps_sync.py
@@ -61,9 +61,9 @@ def test_spec_order_is_preserved(
         note_test_deps=True)
 
     new_spec = json.loads(spec_file.read(), object_pairs_hook=OrderedDict)
-    assert new_spec.keys() == spec_keys + ['test-dependencies']
-    assert new_spec['dependencies'].keys() == ['NoRedInk/spec-1', 'NoRedInk/spec-2', 'NoRedInk/top-1', 'NoRedInk/top-2', 'NoRedInk/top-3']
-    assert new_spec['test-dependencies'].keys() == ['NoRedInk/spec-1', 'NoRedInk/spec-2']
+    assert list(new_spec.keys()) == spec_keys + ['test-dependencies']
+    assert list(new_spec['dependencies'].keys()) == ['NoRedInk/spec-1', 'NoRedInk/spec-2', 'NoRedInk/top-1', 'NoRedInk/top-2', 'NoRedInk/top-3']
+    assert list(new_spec['test-dependencies'].keys()) == ['NoRedInk/spec-1', 'NoRedInk/spec-2']
 
 
 def _make_package(keys, deps):

--- a/tests/test_elm_deps_sync.py
+++ b/tests/test_elm_deps_sync.py
@@ -2,29 +2,55 @@ from collections import OrderedDict
 import json
 
 import pytest
+from hypothesis import given
+import hypothesis.strategies as st
 
 import elm_deps_sync
 
 
-def test_spec_order_is_preserved(tmpdir):
+package_skeleton = {
+    "version": "1.0.0",
+    "summary": "test elm deps sync",
+    "repository": "https://github.com/NoRedInk/elm-ops-tooling",
+    "license": "BSD-3",
+    "source-directories": ".",
+    "exposed-modules": [],
+    "native-modules": True,
+    "dependencies": {},
+    "elm-version": "0.17.0 <= v <= 0.17.0",
+}
+
+top_level_deps = [
+    ('NoRedInk/top-1', '1.0.0 <= v <= 1.0.0'),
+    ('NoRedInk/top-2', '1.0.0 <= v <= 1.0.0'),
+    ('NoRedInk/top-3', '1.0.0 <= v <= 1.0.0'),
+]
+
+spec_deps = [
+    ('NoRedInk/top-1', '1.0.0 <= v <= 1.0.0'),
+    ('NoRedInk/top-2', '1.0.0 <= v <= 1.0.0'),
+    ('NoRedInk/spec-1', '1.0.0 <= v <= 1.0.0'),
+    ('NoRedInk/spec-2', '1.0.0 <= v <= 1.0.0'),
+]
+
+
+@given(top_level_keys=st.permutations(package_skeleton.keys()),
+       top_level_deps=st.permutations(top_level_deps),
+       spec_keys=st.permutations(package_skeleton.keys()),
+       spec_deps=st.permutations(spec_deps))
+def test_spec_order_is_preserved(
+        tmpdir,
+        top_level_keys,
+        top_level_deps,
+        spec_keys,
+        spec_deps):
     top_level_file = tmpdir.join('elm-package.json')
     spec_file = tmpdir.join('spec-elm-package.json')
 
-    top_level = {
-        'dependencies': OrderedDict([
-            ('NoRedInk/top-3', '1.0.0 <= v <= 1.0.0'),
-            ('NoRedInk/top-1', '1.0.0 <= v <= 1.0.0'),
-            ('NoRedInk/top-2', '1.0.0 <= v <= 1.0.0'),
-        ])
-    }
+    top_level = _make_package(top_level_keys, top_level_deps)
     top_level_file.write(json.dumps(top_level))
 
-    spec = {
-        'dependencies': OrderedDict([
-            ('NoRedInk/top-2', '1.0.0 <= v <= 1.0.0'),
-            ('NoRedInk/top-1', '1.0.0 <= v <= 1.0.0'),
-        ])
-    }
+    spec = _make_package(spec_keys, spec_deps)
     spec_file.write(json.dumps(spec))
 
     elm_deps_sync.sync_versions(
@@ -35,4 +61,12 @@ def test_spec_order_is_preserved(tmpdir):
         note_test_deps=True)
 
     new_spec = json.loads(spec_file.read(), object_pairs_hook=OrderedDict)
-    assert new_spec['dependencies'].keys() == ['NoRedInk/top-1', 'NoRedInk/top-2', 'NoRedInk/top-3']
+    assert new_spec.keys() == spec_keys + ['test-dependencies']
+    assert new_spec['dependencies'].keys() == ['NoRedInk/spec-1', 'NoRedInk/spec-2', 'NoRedInk/top-1', 'NoRedInk/top-2', 'NoRedInk/top-3']
+    assert new_spec['test-dependencies'].keys() == ['NoRedInk/spec-1', 'NoRedInk/spec-2']
+
+
+def _make_package(keys, deps):
+    package = OrderedDict((key, package_skeleton[key]) for key in keys)
+    package['dependencies'] = OrderedDict(deps)
+    return package


### PR DESCRIPTION
Using elm_deps_sync should make minimum changes possible. Either

1. As a direct result of running elm_deps_sync
2. As a result of running `elm-package install` afterwards inside the spec folder

In order to do so, there are two pieces to take care of:

1. Order of top-level properties of the spec package (version, summary, description, ...): should be [what's defined by elm-package](https://github.com/elm-lang/elm-package/blob/0.17.1/src/Elm/Package/Description.hs#L95-L105).
  - This is achieved by preserving the order of the keys when reading the spec file, then writing them back as-is.
  -  "test-dependencies" is appended as the last property.
2. Order of dependencies: should be [what's defined by elm-package](https://github.com/elm-lang/elm-package/blob/0.17.1/src/Elm/Package/Description.hs#L107-L111) (sorted alphabetically)
  - This is achieved by sorting dependencies alphabetically when writing back changes.

Other stuff, like matching the JSON format (indentation, etc) with what elm-package outputs, are already taken care of as far as I can see.