### PR TITLE
Avoid adding trailing whitespace on python < 3.4

### DIFF
--- a/elm_deps_sync.py
+++ b/elm_deps_sync.py
@@ -50,7 +50,7 @@ def sync_versions(top_level_file, spec_file, quiet=False, dry=False, note_test_d
         if not dry:
             spec['dependencies'] = sorted_deps(spec['dependencies'])
             with open(spec_file, 'w') as f:
-                json.dump(spec, f, sort_keys=False, indent=4)
+                json.dump(spec, f, sort_keys=False, indent=4, separators=(',', ': '))
         else:
             print("No changes written.")
 

--- a/tests/test_elm_deps_sync.py
+++ b/tests/test_elm_deps_sync.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 import json
+import difflib
 
 import pytest
 from hypothesis import given
@@ -64,6 +65,48 @@ def test_spec_order_is_preserved(
     assert list(new_spec.keys()) == spec_keys + ['test-dependencies']
     assert list(new_spec['dependencies'].keys()) == ['NoRedInk/spec-1', 'NoRedInk/spec-2', 'NoRedInk/top-1', 'NoRedInk/top-2', 'NoRedInk/top-3']
     assert list(new_spec['test-dependencies'].keys()) == ['NoRedInk/spec-1', 'NoRedInk/spec-2']
+
+
+def test_no_trailing_whitespace(tmpdir):
+    top_level_file = tmpdir.join('elm-package.json')
+    spec_file = tmpdir.join('spec-elm-package.json')
+
+    new_dep = ('NoRedInk/top-99', '1.0.0 <= v <= 1.0.0')
+    top_level = _make_package(package_skeleton.keys(), spec_deps + [new_dep])
+    top_level_file.write(json.dumps(top_level))
+
+    sorted_spec_deps = sorted(spec_deps)
+    spec = _make_package(package_skeleton.keys(), sorted_spec_deps)
+    spec_file.write(json.dumps(spec, indent=4, separators=(',', ': ')))
+
+    prev_spec_lines = spec_file.read().splitlines()
+
+    # sanity check: we're operating on a clean JSON
+    for line in prev_spec_lines:
+        assert not line.endswith(' ')
+
+    elm_deps_sync.sync_versions(
+        str(top_level_file),
+        str(spec_file),
+        quiet=False,
+        dry=False,
+        note_test_deps=False)
+
+    for diff in difflib.ndiff(prev_spec_lines, spec_file.read().splitlines()):
+        if diff.startswith('  '):
+            continue
+
+        # assert there's only expected diffs
+        if diff.startswith('+ '):
+            # adds new dep or trailing comma
+            assert (new_dep[0] in diff) or (sorted_spec_deps[-1][0] in diff)
+        elif diff.startswith('- '):
+            # trailing comma
+            assert sorted_spec_deps[-1][0] in diff
+        elif diff.startswith('? '):
+            pass
+        else:
+            assert False, 'unexpected diff operator in: ' + diff
 
 
 def _make_package(keys, deps):


### PR DESCRIPTION
Upstream issue (`json.dump` adds trailing whitespace when `indent` is specified): https://bugs.python.org/issue16333

The recommended workaround for Python < 3.4:

> Since the default item separator is ', ', the output might include trailing whitespace when indent is specified. You can use separators=(',', ': ') to avoid this.
> -- source: https://docs.python.org/2.7/library/json.html

This PR applies this fix and adds a test.