### PR TITLE
Fix find_newer_versions for Removed Packages

### DIFF
--- a/elm_deps_upgrade.py
+++ b/elm_deps_upgrade.py
@@ -92,6 +92,8 @@ def find_newer_versions(local_deps, remote_deps):
     upgrade_suggestions = {}
 
     for (dep, version) in local_deps.items():
+        if dep not in remote_deps:
+            continue
         current_version = top_range(version)
         patches = get_patch_upgrades(current_version, remote_deps[dep]['versions'])
         minors = get_minor_upgrades(current_version, remote_deps[dep]['versions'])


### PR DESCRIPTION
Finding a newer version of a package fails when that package has been
removed or renamed. This patch fixes this by skipping any
removed/renamed packages when attempting to find newer versions.