### PR TITLE
elm_deps_sync: Log message before updating other_package_version

### DIFF
--- a/elm_deps_sync.py
+++ b/elm_deps_sync.py
@@ -28,12 +28,12 @@ def sync_versions(top_level_file, spec_file, quiet=False, dry=False, note_test_d
                 package_name=package_name, spec_file=spec_file, package_version=package_version)
             )
         elif spec['dependencies'][package_name] != package_version:
-            spec['dependencies'][package_name] = package_version
-
             messages.append('Changing {package_name} from version {package_version} to {other_package_version}'.format(
                     package_version=package_version, package_name=package_name,
                     other_package_version=spec['dependencies'][package_name])
-                )
+            )
+
+            spec['dependencies'][package_name] = package_version
 
     test_deps = {}
 


### PR DESCRIPTION
Script was reporting:

```
Changing elm-lang/core from version 3.0.0 <= v < 4.0.0 to 3.0.0 <= v < 4.0.0
```

when the actual diff it produced was

```diff
+        "elm-lang/core": "3.0.0 <= v < 4.0.0",
-        "elm-lang/core": "5.0.0 <= v < 6.0.0",
```
