### PR TITLE
Improve mismatch error message

### DIFF
--- a/elm_deps_check.py
+++ b/elm_deps_check.py
@@ -7,6 +7,18 @@ import argparse
 import textwrap
 
 
+def nice_format(tmpl, *args, **kwargs):
+    unwrapped = textwrap.dedent(tmpl).format(*args, **kwargs)
+
+    paragraphs = [
+        '\n'.join(textwrap.wrap(paragraph))
+        for paragraph
+        in unwrapped.split('\n\n')
+    ]
+
+    return '\n\n'.join(paragraphs)
+
+
 class PackageNotFound(object):
     friendly = textwrap.dedent('''\
     Package {package_name} was a dependency in the reference package file
@@ -23,7 +35,8 @@ class PackageNotFound(object):
         self.candidate_name = candidate_name
 
     def __str__(self):
-        return self.friendly.format(
+        return nice_format(
+            self.friendly,
             package_name=self.package_name,
             reference_name=self.reference_name,
             candidate_name=self.candidate_name,
@@ -54,7 +67,8 @@ class VersionMismatch(object):
         self.candidate_version = candidate_version
 
     def __str__(self):
-        return self.friendly.format(
+        return nice_format(
+            self.friendly,
             package_name=self.package_name,
             reference_name=self.reference_name,
             reference_version=self.reference_version,

--- a/elm_deps_check.py
+++ b/elm_deps_check.py
@@ -152,8 +152,8 @@ def main():
     args = parser.parse_args()
 
     if args.exact:
-        print("WARNING: --exact is deprecated and will be removed in a future version.")
-        print("compare your elm-package.json files directly!")
+        print("WARNING: --exact is deprecated and will be removed in a future version.", file=sys.stderr)
+        print("compare your elm-package.json files directly!", file=sys.stderr)
 
     if not have_matching_versions(args.reference_file, args.candidate_file, quiet=args.quiet, is_exact=args.exact):
         sys.exit(1)

--- a/elm_deps_check.py
+++ b/elm_deps_check.py
@@ -14,7 +14,7 @@ class PackageNotFound(object):
     ({candidate_name}).
 
     You can probably fix this error by adding {package_name} to the
-    dependencies in {candidate_name}.
+    dependencies in {candidate_name}.\
     ''')
 
     def __init__(self, package_name, reference_name, candidate_name):
@@ -38,8 +38,8 @@ class VersionMismatch(object):
     "{reference_version}", but the candidate package file ({candidate_name})
     has version "{candidate_version}".
 
-    You can probably fix this error by making the version bounds in
-    {candidate_name} exactly match those in {reference_name}.
+    You can probably fix this error by changing the version bounds for
+    {package_name} in {candidate_name} to "{reference_version}".\
     ''')
 
     def __init__(
@@ -105,7 +105,8 @@ def have_matching_versions(reference_file, candidate_file, is_exact=False, quiet
 
     if len(errors) > 0:
         print('BUILD FAILED due to elm-deps mismatch, errors:')
-        print('\n'.join(str(error) for error in errors))
+        print('\n---\n')
+        print('\n\n---\n\n'.join(str(error) for error in errors))
         return False
     else:
         if not quiet:
@@ -140,7 +141,7 @@ def main():
         print("WARNING: --exact is deprecated and will be removed in a future version.")
         print("compare your elm-package.json files directly!")
 
-    if not have_matching_versions(args.top_level_file, args.spec_file, quiet=args.quiet, is_exact=args.exact):
+    if not have_matching_versions(args.reference_file, args.candidate_file, quiet=args.quiet, is_exact=args.exact):
         sys.exit(1)
 
 

--- a/elm_deps_check.py
+++ b/elm_deps_check.py
@@ -4,59 +4,141 @@ from __future__ import print_function
 import sys
 import json
 import argparse
+import textwrap
 
 
-def have_matching_versions(top_level_file, spec_file, is_exact=False, quiet=True):
-    """ first file should be the top level elm-package exact-dependencies.json
-        second file should be the spec file
+class PackageNotFound(object):
+    friendly = textwrap.dedent('''\
+    Package {package_name} was a dependency in the reference package file
+    ({reference_name}) but was not in the candidate package file
+    ({candidate_name}).
+
+    You can probably fix this error by adding {package_name} to the
+    dependencies in {candidate_name}.
+    ''')
+
+    def __init__(self, package_name, reference_name, candidate_name):
+        self.package_name = package_name
+        self.reference_name = reference_name
+        self.candidate_name = candidate_name
+
+    def __str__(self):
+        return self.friendly.format(
+            package_name=self.package_name,
+            reference_name=self.reference_name,
+            candidate_name=self.candidate_name,
+        )
+
+
+class VersionMismatch(object):
+    friendly = textwrap.dedent('''\
+    Package version mismatch for {package_name}!
+
+    The reference package file ({reference_name}) has version
+    "{reference_version}", but the candidate package file ({candidate_name})
+    has version "{candidate_version}".
+
+    You can probably fix this error by making the version bounds in
+    {candidate_name} exactly match those in {reference_name}.
+    ''')
+
+    def __init__(
+            self,
+            package_name,
+            reference_name, reference_version,
+            candidate_name, candidate_version):
+        self.package_name = package_name
+        self.reference_name = reference_name
+        self.reference_version = reference_version
+        self.candidate_name = candidate_name
+        self.candidate_version = candidate_version
+
+    def __str__(self):
+        return self.friendly.format(
+            package_name=self.package_name,
+            reference_name=self.reference_name,
+            reference_version=self.reference_version,
+            candidate_name=self.candidate_name,
+            candidate_version=self.candidate_version,
+        )
+
+
+def have_matching_versions(reference_file, candidate_file, is_exact=False, quiet=True):
+    """ first file should be the top level elm-package.json
+        second file should be the spec file elm-package.json
     """
-
-    with open(top_level_file) as f:
-        top_level = json.load(f)
-
-    with open(spec_file) as f:
-        spec = json.load(f)
+    reference = json.load(reference_file)
+    candidate = json.load(candidate_file)
 
     if not is_exact:
-        top_level = top_level['dependencies']
-        spec = spec['dependencies']
+        reference = reference['dependencies']
+        candidate = candidate['dependencies']
 
     if not quiet:
-        print(top_level_file, json.dumps(top_level, sort_keys=True, indent=4))
-        print(spec_file, json.dumps(spec, sort_keys=True, indent=4))
+        print(
+            reference_file.name,
+            json.dumps(reference, sort_keys=True, indent=4),
+        )
+        print(
+            candidate_file.name,
+            json.dumps(candidate, sort_keys=True, indent=4),
+        )
 
     errors = []
 
-    for (package_name, package_version) in top_level.items():
-        if package_name not in spec:
-            errors.append('Package {package_name} not found in {spec_file}, but was found in {top_level_file}'.format(
-                package_name=package_name, spec_file=spec_file, top_level_file=top_level_file)
-            )
-        elif spec[package_name] != package_version:
-            errors.append('Package version mismatch for'
-                ' {package_name}!\n\n {top_level_file} had {package_version}\n {spec_file} had {other_package_version}'.format(
-                    package_version=package_version, package_name=package_name, top_level_file=top_level_file,
-                    spec_file=spec_file, other_package_version=spec[package_name])
-                )
+    for (package_name, package_version) in reference.items():
+        if package_name not in candidate:
+            errors.append(PackageNotFound(
+                package_name=package_name,
+                reference_name=reference_file.name,
+                candidate_name=candidate_file.name,
+            ))
+
+        elif candidate[package_name] != package_version:
+            errors.append(VersionMismatch(
+                package_name=package_name,
+                reference_name=reference_file.name,
+                reference_version=package_version,
+                candidate_name=candidate_file.name,
+                candidate_version=candidate[package_name],
+            ))
 
     if len(errors) > 0:
         print('BUILD FAILED due to elm-deps mismatch, errors:')
-        print('\n'.join(errors))
+        print('\n'.join(str(error) for error in errors))
         return False
     else:
-        print('Matching deps!')
+        if not quiet:
+            print('Matching deps!')
         return True
 
+
 def main():
+    parser = argparse.ArgumentParser(
+        description='check that deps match between two elm-package.json files.'
+    )
 
-    parser = argparse.ArgumentParser(description='Check deps matching between a parent and a sub')
+    # arguments
+    parser.add_argument(
+        'reference_file', type=open,
+        help='the source of truth for dependency comparisons',
+    )
+    parser.add_argument(
+        'candidate_file', type=open,
+        help='the file which should change if different from the reference',
+    )
 
-    parser.add_argument('--quiet', '-q', action='store_true', help='don\'t print anything', default=False)
-    parser.add_argument('--exact', '-e', action='store_true', help='these files are exact dependencies', default=False)
+    # options
+    parser.add_argument('--quiet', '-q', action='store_true', help='succeed quietly instead of printing the dependencies as they are examined', default=False)
 
-    parser.add_argument('top_level_file')
-    parser.add_argument('spec_file')
+    # deprecated options
+    parser.add_argument('--exact', '-e', action='store_true', help='(DEPRECATED) these files are exact dependencies', default=False)
+
     args = parser.parse_args()
+
+    if args.exact:
+        print("WARNING: --exact is deprecated and will be removed in a future version.")
+        print("compare your elm-package.json files directly!")
 
     if not have_matching_versions(args.top_level_file, args.spec_file, quiet=args.quiet, is_exact=args.exact):
         sys.exit(1)


### PR DESCRIPTION
Changes the error messages to be a little friendlier:

```
BUILD FAILED due to elm-deps mismatch, errors:

---

Package cuducos/elm-format-number was a dependency in the reference package file
(ui/elm-package.json) but was not in the candidate package file
(ui/tests/elm-package.json).

You can probably fix this error by adding cuducos/elm-format-number to the
dependencies in ui/tests/elm-package.json.

---

Package version mismatch for test/bad!

The reference package file (ui/elm-package.json) has version
"1.0.1 <= v <= 1.0.1", but the candidate package file (ui/tests/elm-package.json)
has version "1.0.0 <= v <= 1.0.0".

You can probably fix this error by changing the version bounds for
test/bad in ui/tests/elm-package.json to "1.0.1 <= v <= 1.0.1".
```