### PR TITLE
Enable timeouts when retreiving content via url.

### DIFF
--- a/native_package_install.py
+++ b/native_package_install.py
@@ -8,12 +8,7 @@ import fnmatch
 import os
 import sys
 import tarfile
-try:
-    # For Python 3.0 and later
-    from urllib.request import urlretrieve
-except ImportError:
-    # Fall back to Python 2's urllib2
-    from urllib import urlretrieve
+import requests
 
 import elm_package
 import exact_dependencies
@@ -86,6 +81,13 @@ def vendor_package_dir(vendor_dir, package):
         version=package['version']
     )
 
+
+def urlretrieve(url, filename, timeout = 60):
+    response = requests.get(url, timeout=timeout, stream=True)
+    response.raise_for_status()
+    with open(filename, "wb") as output:
+        for chunk in response.iter_content(4096):
+            output.write(chunk)
 
 def fetch_packages(vendor_dir, packages):
     """


### PR DESCRIPTION
I noticed a build was blocked this morning in native_package_install.py and assume 
it is because we don't timeout the url read request. I'm happy for this to be closed if 
others don't believe it adds value.

Previously we used urllib.request.urlretrieve which had no timeout. This
changes to use requests.get with a timeout and streams content to the
output file.

This is to avoid native_package_install blocking when github
connectivity issues occur.

💭 We could wrap a retry here as well to avoid the retry being at the outer edge of asset_dependencies (though that also catches other cases).